### PR TITLE
allow configurable filtering for active profiles

### DIFF
--- a/src/main/kotlin/de/uksh/medic/fhirmarshal/AppProperties.kt
+++ b/src/main/kotlin/de/uksh/medic/fhirmarshal/AppProperties.kt
@@ -14,10 +14,15 @@ import java.net.URI
 data class AppProperties(
     val remoteStructureServers: Map<String, ServerSettings>,
     val remoteTerminologyServers: Map<String, ServerSettings>,
+    val retrieveOnlyActiveProfiles: Boolean = true,
     val retrievalPageSize: Int = 3
 ) {
     data class ServerSettings(
-        val url: URI, val authUser: String? = null, val authPassword: String? = null, val overridePageSize: Int? = null
+        val url: URI,
+        val authUser: String? = null,
+        val authPassword: String? = null,
+        val overridePageSize: Int? = null,
+        val overrideRetrieveOnlyActiveProfiles: Boolean? = null
     ) {
         fun configureRestTemplate() = RestTemplate().apply {
             if (authUser != null && authPassword != null) {

--- a/src/main/kotlin/de/uksh/medic/fhirmarshal/controller/ValidationController.kt
+++ b/src/main/kotlin/de/uksh/medic/fhirmarshal/controller/ValidationController.kt
@@ -34,9 +34,10 @@ class ValidationController(
     fun postValidation(requestEntity: RequestEntity<String>): String {
         val (iBaseResource, parser) = consumeTextBody(requestEntity) ?: (null to null)
         if (iBaseResource != null && parser != null) {
-            logger.info("${iBaseResource.fhirType()} from ${requestEntity.headers}")
             val out = validationService.validateResource(iBaseResource)
-            return parser.setPrettyPrint(true).encodeResourceToString(out)
+            return parser.setPrettyPrint(true).encodeResourceToString(out).also {
+                logger.info("${iBaseResource.fhirType()} from ${requestEntity.headers}, validated: ${out.issue.size} issues")
+            }
         } else {
             throw ResponseStatusException(
                 HttpStatus.BAD_REQUEST,

--- a/src/main/kotlin/de/uksh/medic/fhirmarshal/services/ValidationSupportConfiguration.kt
+++ b/src/main/kotlin/de/uksh/medic/fhirmarshal/services/ValidationSupportConfiguration.kt
@@ -41,6 +41,7 @@ class ValidationSupportConfiguration(
             PrePopulatedValidationSupport(this@ValidationSupportConfiguration.fhirContext)
         retrieveStructureDefinitions().forEach {
             prePopulatedValidationSupport.addStructureDefinition(it)
+            logger.debug("Registered ${it.url}")
             /* TODO: 2022-08-29 [JW] We are currently keeping all the StructureDefinions in-memory.
                 Maybe externalize to a temp directory?
                 This would require a custom implementation of IValidationSupport that uses Files.createTempDirectory
@@ -85,7 +86,9 @@ class ValidationSupportConfiguration(
             pathSegment("StructureDefinition")
             queryParam("_count", pageSize)
             queryParam("_total", "accurate") // this might be ignored by some servers
-            queryParam("status", "active")
+            if (server.overrideRetrieveOnlyActiveProfiles ?: properties.retrieveOnlyActiveProfiles) {
+                queryParam("status", "active")
+            }
         }.build().toUri()
         logger.info("Starting StructureDefinition retrieval from $serverName (page size=$pageSize) at: $startUri")
         var currentUri: URI? = startUri


### PR DESCRIPTION
in prior versions, only active profiles were downloaded by default. Now, this is the default behaviour, but this can be overridden globally or per-server